### PR TITLE
찜기능 API 수정 구현 완료

### DIFF
--- a/server/musinsa_list/models.py
+++ b/server/musinsa_list/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from accounts.models import User
 
 class Goods(models.Model):
     id = models.IntegerField(primary_key=True)
@@ -6,3 +7,9 @@ class Goods(models.Model):
     brand_name = models.CharField(max_length=100)
     s3_img_url = models.URLField()
     detail_page_url = models.URLField()
+
+
+class Dips(models.Model):
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    goods = models.ForeignKey(Goods, on_delete=models.CASCADE)
+    

--- a/server/musinsa_list/serializers.py
+++ b/server/musinsa_list/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import Goods
+from .models import Goods, Dips
 
 class GoodsListSerializer(serializers.ModelSerializer):
     class Meta:
@@ -18,3 +18,17 @@ class GoodsDetailSerializer(serializers.ModelSerializer):
 
     id = serializers.CharField(max_length=100)
     detail_page_url = serializers.URLField(max_length=200)
+
+
+class DipsListSerializer(serializers.ModelSerializer):
+    goods_info = serializers.SerializerMethodField()
+
+    def get_goods_info(self, obj):
+        info = {'id' : obj.goods.id,
+                'goods_name' : obj.goods.goods_name,
+                'brand_name' : obj.goods.brand_name,
+                's3_img_url' : obj.goods.s3_img_url}
+        return info
+    class Meta:
+        model = Dips
+        fields = ['goods_info']

--- a/server/musinsa_list/urls.py
+++ b/server/musinsa_list/urls.py
@@ -5,7 +5,7 @@ urlpatterns = [
     path('send-result', RecieveCrawlingResultView.as_view()),
     path('cloth-list', ShowClothListView.as_view()),
     path('detail-page', ShowDetailView.as_view()),
-    path('dips/add', DipsView.as_view({'post': 'post_add'})),
+    path('dips/add', DipsView.as_view({'post': 'post_add'})), 
     path('dips/show', DipsView.as_view({'post': 'post_show'})),
-    path('dips/delete', DipsView.as_view({'delete': 'delete'}))
+    path('dips/delete', DipsView.as_view({'delete': 'delete'})),
 ]

--- a/server/musinsa_list/urls.py
+++ b/server/musinsa_list/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views import RecieveCrawlingResultView, ShowClothListView, ShowDetailView
+from .views import RecieveCrawlingResultView, ShowClothListView, ShowDetailView, DipsView
 
 urlpatterns = [
     path('send-result', RecieveCrawlingResultView.as_view()),
     path('cloth-list', ShowClothListView.as_view()),
     path('detail-page', ShowDetailView.as_view()),
+    path('dips', DipsView.as_view()),
 ]

--- a/server/musinsa_list/urls.py
+++ b/server/musinsa_list/urls.py
@@ -5,5 +5,7 @@ urlpatterns = [
     path('send-result', RecieveCrawlingResultView.as_view()),
     path('cloth-list', ShowClothListView.as_view()),
     path('detail-page', ShowDetailView.as_view()),
-    path('dips', DipsView.as_view()),
+    path('dips/add', DipsView.as_view({'post': 'post_add'})),
+    path('dips/show', DipsView.as_view({'post': 'post_show'})),
+    path('dips/delete', DipsView.as_view({'delete': 'delete'}))
 ]

--- a/server/musinsa_list/views.py
+++ b/server/musinsa_list/views.py
@@ -62,3 +62,13 @@ class DipsView(View):
         serializer = DipsListSerializer(queryset, many=True)
 
         return JsonResponse({'data' : serializer.data}, safe=False)
+
+    def delete(self, request):
+        # need user_id, goods_id
+        data = json.loads(request.body)
+
+        item = Dips.objects.get(user_id=data['user_id'], goods_id=data['goods_id'])
+        item.delete()
+
+        return JsonResponse({'message' : '찜 목록 상품 삭제 성공'}, status=200)
+

--- a/server/musinsa_list/views.py
+++ b/server/musinsa_list/views.py
@@ -3,7 +3,8 @@ from django.views import View
 from django.http import JsonResponse
 
 from .serializers import GoodsListSerializer, GoodsDetailSerializer
-from .models import Goods
+from .models import Goods, Dips
+from accounts.models import User
 
 class RecieveCrawlingResultView(View):
     def post(self, request):
@@ -38,3 +39,19 @@ class ShowDetailView(View):
         serializer = GoodsDetailSerializer(queryset, many=True)
         
         return JsonResponse({'data' : serializer.data}, safe=False)
+
+
+class DipsView(View):
+    def post(self, request):
+        # need user_id, goods_id
+        data = json.loads(request.body)
+
+        Dips(
+            user = User.objects.get(user_id=data['user_id']),
+            goods = Goods.objects.get(id=data['goods_id'])
+        ).save()
+
+        return JsonResponse({'message' : '찜 목록 추가 성공'}, status=200)
+    
+    def get(self, request):
+        pass

--- a/server/musinsa_list/views.py
+++ b/server/musinsa_list/views.py
@@ -1,6 +1,8 @@
 import json
 from django.views import View
 from django.http import JsonResponse
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.decorators import action
 
 from .serializers import GoodsListSerializer, GoodsDetailSerializer, DipsListSerializer
 from .models import Goods, Dips
@@ -41,8 +43,9 @@ class ShowDetailView(View):
         return JsonResponse({'data' : serializer.data}, safe=False)
 
 
-class DipsView(View):
-    def post(self, request):
+class DipsView(ModelViewSet):
+    @action(methods=['POST'], detail=False)
+    def post_add(self, request):
         # need user_id, goods_id
         data = json.loads(request.body)
 
@@ -53,7 +56,8 @@ class DipsView(View):
 
         return JsonResponse({'message' : '찜 목록 추가 성공'}, status=200)
     
-    def get(self, request):
+    @action(methods=['POST'], detail=False)
+    def post_show(self, request):
         # need user_id
         data = json.loads(request.body)
 
@@ -63,6 +67,7 @@ class DipsView(View):
 
         return JsonResponse({'data' : serializer.data}, safe=False)
 
+    @action(methods=['DELETE'], detail=False)
     def delete(self, request):
         # need user_id, goods_id
         data = json.loads(request.body)

--- a/server/musinsa_list/views.py
+++ b/server/musinsa_list/views.py
@@ -49,12 +49,15 @@ class DipsView(ModelViewSet):
         # need user_id, goods_id
         data = json.loads(request.body)
 
-        Dips(
-            user = User.objects.get(user_id=data['user_id']),
-            goods = Goods.objects.get(id=data['goods_id'])
-        ).save()
+        if Dips.objects.filter(user_id=data['user_id'], goods_id=data['goods_id']).exists():
+            return JsonResponse({'message' : 'Already Added Item'}, status=200)
+        else:
+            Dips(
+                user = User.objects.get(user_id=data['user_id']),
+                goods = Goods.objects.get(id=data['goods_id'])
+            ).save()
 
-        return JsonResponse({'message' : '찜 목록 추가 성공'}, status=200)
+            return JsonResponse({'message' : '찜 목록 추가 성공'}, status=200)
     
     @action(methods=['POST'], detail=False)
     def post_show(self, request):

--- a/server/musinsa_list/views.py
+++ b/server/musinsa_list/views.py
@@ -2,7 +2,7 @@ import json
 from django.views import View
 from django.http import JsonResponse
 
-from .serializers import GoodsListSerializer, GoodsDetailSerializer
+from .serializers import GoodsListSerializer, GoodsDetailSerializer, DipsListSerializer
 from .models import Goods, Dips
 from accounts.models import User
 
@@ -54,4 +54,11 @@ class DipsView(View):
         return JsonResponse({'message' : '찜 목록 추가 성공'}, status=200)
     
     def get(self, request):
-        pass
+        # need user_id
+        data = json.loads(request.body)
+
+        queryset = Dips.objects.filter(user_id=data['user_id'])
+        
+        serializer = DipsListSerializer(queryset, many=True)
+
+        return JsonResponse({'data' : serializer.data}, safe=False)


### PR DESCRIPTION
@dh5473 의 코드리뷰 피드백을 반영하여 get 메소드를 Post 로 바꾸어 수정완료했습니다.
이전 PR이 머지가 되어서... 새로 PR 올립니다.

동작 테스트결과 정상적으로 작동합니다. 
post 를 두개 사용하면서 엔드포인트 부분에서 수정사항이 생겼으니 @grapefruit224 께서는 변경된 url 확인 부탁드립니다.

### 찜목록 추가 (POST)
Client : POST http://35.84.85.252:8000/goods/dips/add
data : {
    "user_id" : "user_id",
    "goods_id" : goods_id
}

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/72314987/234581153-55ef610d-7933-46e4-be27-76b3f81028fc.png">

### 찜목록 삭제 (DELETE)
Client : DELETE http://35.84.85.252:8000/goods/dips/delete
data : {
    "user_id" : "user_id",
    "goods_id" : goods_id
}

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/72314987/234581254-f785a7c8-86ae-4a12-9ee4-b1aee5686350.png">


### 찜목록 보여주기 (POST)
Client : POST http://35.84.85.252:8000/goods/dips/show
data : {
    "user_id" : "user_id"
}

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/72314987/234581303-bd386377-2c07-4eba-8ccf-bc6510b6b6d0.png">


# 그 외 수정사항
찜목록 추가할 때 DB 확인해서 이미 uid - goods_id 가 이미 존재하는 경우도 추가했습니다. 프론트단에서 처리할 수 있지만 백에서도 우선 해두었습니다.

그리고, JWT 구현되고나면 data 에 보낼 값이 수정될 수 있으니 알고만 있어 주시면 되겠습니다. 구현되면 그때 정리해서 알려드리겠습니다.

