### PR TITLE
modify to get bucket, file name from client

### DIFF
--- a/server/s3_access/views.py
+++ b/server/s3_access/views.py
@@ -4,20 +4,17 @@ import botocore
 from django.views import View
 from django.http import JsonResponse
 
-BUCKET_NAME = "user-human-img"
-
 class CreatePresignedUrl(View):
     def get(self, request):
-        # get user_id
         data = json.loads(request.body)
-        user_id = data['user_id']
-
-        image_path = f"{user_id}.jpg"
+        
+        bucket_name = data['bucket_name']
+        file_path = data['file_path']
 
         client = boto3.client('s3',config=botocore.client.Config(signature_version='s3v4'))
         presigned_url = client.generate_presigned_url(ClientMethod='put_object',
-                                                      Params={'Bucket' : BUCKET_NAME,
-                                                                'Key' : image_path},
+                                                      Params={'Bucket' : bucket_name,
+                                                                'Key' : file_path},
                                                       ExpiresIn=300)
         
         return JsonResponse({'data' : presigned_url}, status=200)


### PR DESCRIPTION
client 에서 get 요청시 data에

{'bucket_name' : 버킷명,
'file_path' : 파일경로 (. 확장자 포함) }

담아서 보내주시면 해당 버킷, 파일명으로 presigned url 반환하도록 수정했습니다.